### PR TITLE
feat: add pin/unpin actions for active app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # move-win-vd
 
-A minimal Windows utility that moves the active window to an adjacent virtual desktop.
+A minimal Windows utility that moves, pins, and unpins the active window across virtual desktops.
 
 ## Requirements
 
@@ -48,7 +48,7 @@ The most convenient way to use this tool is to bind it to keyboard shortcuts via
 ## Command Line
 
 ```
-move-win-vd.exe r|l [/w] [/s]
+move-win-vd.exe r|l|p|u|pa|ua [/w] [/s]
 ```
 
 ### Arguments
@@ -57,8 +57,12 @@ move-win-vd.exe r|l [/w] [/s]
 |----------|-------------|
 | `r` | Move the active window to the **next** (right) virtual desktop |
 | `l` | Move the active window to the **previous** (left) virtual desktop |
+| `p` | Pin the active window so it appears on **all** virtual desktops |
+| `u` | Unpin the active window |
+| `pa` | Pin the active window's **app** on all virtual desktops |
+| `ua` | Unpin the active window's **app** |
 
-The `r` or `l` argument is required.
+One action argument is required.
 
 ### Options
 
@@ -67,7 +71,7 @@ The `r` or `l` argument is required.
 | `/w` | **Wrap around** — if at the last desktop, move to the first (and vice versa) |
 | `/s` | **Switch** — also move your view to the destination desktop |
 
-Options can be combined freely.
+`/w` and `/s` apply to `r`/`l` move actions only.
 
 ### Examples
 
@@ -83,7 +87,23 @@ move-win-vd.exe r /s
 
 # Move window to the previous desktop, follow it, and wrap around
 move-win-vd.exe l /s /w
+
+# Pin the active window on all desktops
+move-win-vd.exe p
+
+# Unpin the active window
+move-win-vd.exe u
+
+# Pin/unpin the active app on all desktops
+move-win-vd.exe pa
+move-win-vd.exe ua
 ```
+
+### Pin/Unpin Behavior Note
+
+Virtual desktop pinning behavior is determined by the Windows API used by `winvd`.
+If an app is pinned, unpinning one of its windows may unpin the app-level pin state.
+If you want explicit app-level control, prefer `pa` and `ua`.
 
 <br>
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,8 @@ use std::env;
 use std::process;
 use windows::Win32::UI::WindowsAndMessaging::GetForegroundWindow;
 use winvd::{
-    get_current_desktop, get_desktop_count, move_window_to_desktop, pin_window, switch_desktop,
-    unpin_window,
+    get_current_desktop, get_desktop_count, move_window_to_desktop, pin_app, pin_window,
+    switch_desktop, unpin_app, unpin_window,
 };
 
 fn main() {
@@ -18,6 +18,8 @@ fn main() {
         Left,
         Pin,
         Unpin,
+        PinApp,
+        UnpinApp,
     }
 
     // Parse the first positional argument to determine the action
@@ -26,6 +28,8 @@ fn main() {
         Some("l") => WindowAction::Left,
         Some("p") => WindowAction::Pin,
         Some("u") => WindowAction::Unpin,
+        Some("pa") => WindowAction::PinApp,
+        Some("ua") => WindowAction::UnpinApp,
         _ => process::exit(1),
     };
 
@@ -43,6 +47,18 @@ fn main() {
 
     // Pin/unpin are terminal actions; only left/right continue to move logic.
     match action {
+        WindowAction::PinApp => {
+            if pin_app(hwnd).is_err() {
+                process::exit(1);
+            }
+            return;
+        }
+        WindowAction::UnpinApp => {
+            if unpin_app(hwnd).is_err() {
+                process::exit(1);
+            }
+            return;
+        }
         WindowAction::Pin => {
             if pin_window(hwnd).is_err() {
                 process::exit(1);


### PR DESCRIPTION
Add CLI actions to pin and unpin the active app via winvd. Keep pin/unpin app terminal paths so move logic only runs for left/right ops.
Update README with new command usage and a behavior note about app-level pin interactions.

Closes #3
